### PR TITLE
Use sanitize_title rather than sanitize_user for user_nicename

### DIFF
--- a/shibboleth.php
+++ b/shibboleth.php
@@ -500,12 +500,12 @@ function shibboleth_update_user_data($user_id, $force_update = false) {
 
 
 /**
- * Sanitize the nicename using sanitize_user
+ * Sanitize the nicename using sanitize_title
  * See discussion: http://wordpress.org/support/topic/377030
  *
  * @since 1.4
  */
-add_filter( 'shibboleth_user_nicename', 'sanitize_user' );
+add_filter( 'shibboleth_user_nicename', 'sanitize_title' );
 
 /**
  * Add a "Login with Shibboleth" link to the WordPress login form.  This link


### PR DESCRIPTION
user_nicename is often used for URLs as a slug to the user. Comparing the documentation for the two functions, sanitize_title is the one that generates a URL-safe slug.

https://codex.wordpress.org/Function_Reference/sanitize_title
https://codex.wordpress.org/Function_Reference/sanitize_user