### PR TITLE
Skip "Email Change" email for Shibboleth users

### DIFF
--- a/shibboleth.php
+++ b/shibboleth.php
@@ -622,6 +622,9 @@ function shibboleth_update_user_data( $user_id, $force_update = false ) {
 		}
 	}
 
+	// Shibboleth users do not use their email address for authentication.
+	add_filter( 'send_email_change_email', '__return_false' );
+	
 	wp_update_user( $user_data );
 }
 


### PR DESCRIPTION
WordPress, by default, notifies users when their email has changed because the user, by default, uses that email address for authentication purposes. When the email field is managed by the Shibboleth plugin, it will update the user account to match the fields coming from Shibboleth attributes. Given that the purpose of the notification is not relevant to Shibboleth authenticated users, it makes sense to not send the notification.