### PR TITLE
auth: Blank Shibboleth role means use existing WordPress access

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -153,7 +153,7 @@ Yes, the plugin allows for all settings to be controlled via constants in `wp-co
  - `SHIBBOLETH_DEFAULT_ROLE`
    - Format: string
    - Available options: All available WordPress roles. The defaults are `'administrator'`, `'subscriber'`, `'author'`, `'editor'`, and `'contributor'`. Leave this constant empty `''` to make the default no allowed access.
-   - Example: `define('SHIBBOLETH_MANUALLY_COMBINE_ACCOUNTS', 'subscriber');`
+   - Example: `define('SHIBBOLETH_DEFAULT_ROLE', 'subscriber');`
  - `SHIBBOLETH_UPDATE_ROLES`
    - Format: boolean
    - Available options: `true` to automatically use Shibboleth data to update user role mappings each time the user logs in or `false` to only update role mappings when a user is initally created.

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -481,13 +481,6 @@ function shibboleth_authenticate_user() {
 		$manually_combine_accounts = get_site_option( 'shibboleth_manually_combine_accounts', 'disallow' );
 	}
 
-	// ensure user is authorized to login
-	$user_role = shibboleth_get_user_role();
-
-	if ( empty( $user_role ) ) {
-		return new WP_Error( 'no_access', __( 'You do not have sufficient access.' ) );
-	}
-
 	$username = shibboleth_getenv( $shib_headers['username']['name'] );
 	$email = shibboleth_getenv( $shib_headers['email']['name'] );
 
@@ -548,6 +541,7 @@ function shibboleth_authenticate_user() {
 	}
 
 	if ( $update ) {
+		$user_role = shibboleth_get_user_role();
 		$user->set_role( $user_role );
 		do_action( 'shibboleth_set_user_roles', $user );
 	}
@@ -623,19 +617,7 @@ function shibboleth_get_user_role() {
 		$shib_roles = apply_filters( 'shibboleth_roles', get_site_option( 'shibboleth_roles' ) );
 	}
 
-
-
-	if ( defined( 'SHIBBOLETH_CREATE_ACCOUNTS' ) ) {
-		$create_accounts = SHIBBOLETH_CREATE_ACCOUNTS;
-	} else {
-		$create_accounts = get_site_option( 'shibboleth_create_accounts' );
-	}
-
-	if ( $create_accounts != false ) {
-		$user_role = get_site_option( 'shibboleth_default_role' );
-	} else {
-		$user_role = 'none';
-	}
+	$user_role = get_site_option( 'shibboleth_default_role' );
 
 	foreach ( $wp_roles->role_names as $key => $name ) {
 		if ( isset( $shib_roles[$key]['header'] ) ) {

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -617,7 +617,11 @@ function shibboleth_get_user_role() {
 		$shib_roles = apply_filters( 'shibboleth_roles', get_site_option( 'shibboleth_roles' ) );
 	}
 
-	$user_role = get_site_option( 'shibboleth_default_role' );
+	if ( defined( 'SHIBBOLETH_DEFAULT_ROLE' ) ) {
+		$user_role = SHIBBOLETH_DEFAULT_ROLE;
+	} else {
+		$user_role = get_site_option( 'shibboleth_default_role' );
+	}
 
 	foreach ( $wp_roles->role_names as $key => $name ) {
 		if ( isset( $shib_roles[$key]['header'] ) ) {


### PR DESCRIPTION
``shibboleth_get_user_role()`` is currently used for three things:

1. When creating a new account, it provides the initial role to set for the new account.
2. When role updates are enabled, it provides the role to set for the existing account.
3. When the user is logging in, if the value returned is blank, it prevents access.

The third use is not valid. ``shibboleth_create_new_user()`` already checks whether accounts can be created. ``shibboleth_authenticate_user()`` already checks to make sure an account exists. And most importantly, if the user account exists and is already tied to Shibboleth, our job as an authentication mechanism is to map the user to the user's account. Authorization should be done by WordPress based on roles that have been assigned to the user.

With this change in place, a couple things start working:

- When ``shibboleth_create_accounts`` is disabled and ``shibboleth_update_roles`` is enabled, the default role is correctly set.
- When ``shibboleth_create_accounts`` is enabled and ``shibboleth_default_role`` is blank, users can log in. (Fixes #36)