### PR TITLE
i18n: Add Text Domain header

### DIFF
--- a/shibboleth.php
+++ b/shibboleth.php
@@ -6,6 +6,7 @@
  Author: Michael McNeill, mitcho (Michael 芳貴 Erlewine), Will Norris
  Version: 2.0.2
  License: Apache 2 (http://www.apache.org/licenses/LICENSE-2.0.html)
+ Text Domain: shibboleth
  */
 
 define( 'SHIBBOLETH_MINIMUM_WP_VERSION', '3.3' );


### PR DESCRIPTION
Allows translate.wordpress.org compatibility

References:
https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/
https://make.wordpress.org/core/2016/07/06/i18n-improvements-in-4-6/