### PR TITLE
Debug login from frontend

### DIFF
--- a/shibboleth.php
+++ b/shibboleth.php
@@ -861,13 +861,13 @@ add_filter( 'lostpassword_url', 'shibboleth_custom_password_reset_url' );
  * @since 1.0
  */
 function shibboleth_login_form() {
-    global $wp;
-    $url = false;
-    if ( isset( $wp->request ) ) {
-        $url = wp_login_url( home_url( $wp->request ) );
-    }
-    $login_url = add_query_arg( 'action', 'shibboleth', $url );
-   	$login_url = remove_query_arg( 'reauth', $login_url );
+	global $wp;
+	$url = false;
+	if ( isset( $wp->request ) ) {
+		$url = wp_login_url( home_url( $wp->request ) );
+	}
+	$login_url = add_query_arg( 'action', 'shibboleth', $url );
+	$login_url = remove_query_arg( 'reauth', $login_url );
 	$button_text = shibboleth_getoption( 'shibboleth_button_text', 'Log in with Shibboleth' );
 	$disable = shibboleth_getoption( 'shibboleth_disable_local_auth', false );
 	?>

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -861,9 +861,13 @@ add_filter( 'lostpassword_url', 'shibboleth_custom_password_reset_url' );
  * @since 1.0
  */
 function shibboleth_login_form() {
-	global $wp;
-	$login_url = add_query_arg( 'action', 'shibboleth', wp_login_url( home_url( $wp->request ) ) );
-	$login_url = remove_query_arg( 'reauth', $login_url );
+    global $wp;
+    $url = false;
+    if ( isset( $wp->request ) ) {
+        $url = wp_login_url( home_url( $wp->request ) );
+    }
+    $login_url = add_query_arg( 'action', 'shibboleth', $url );
+   	$login_url = remove_query_arg( 'reauth', $login_url );
 	$button_text = shibboleth_getoption( 'shibboleth_button_text', 'Log in with Shibboleth' );
 	$disable = shibboleth_getoption( 'shibboleth_disable_local_auth', false );
 	?>

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -861,7 +861,8 @@ add_filter( 'lostpassword_url', 'shibboleth_custom_password_reset_url' );
  * @since 1.0
  */
 function shibboleth_login_form() {
-	$login_url = add_query_arg( 'action', 'shibboleth' );
+	global $wp;
+	$login_url = add_query_arg( 'action', 'shibboleth', wp_login_url( home_url( $wp->request ) ) );
 	$login_url = remove_query_arg( 'reauth', $login_url );
 	$button_text = shibboleth_getoption( 'shibboleth_button_text', 'Log in with Shibboleth' );
 	$disable = shibboleth_getoption( 'shibboleth_disable_local_auth', false );


### PR DESCRIPTION
Here is a general fix to take into account the situation where the login form is displayed outside the login page, for instance when a theme display a login form in a menu or as a widget.