### PR TITLE
Version 2.3

### DIFF
--- a/options-admin.php
+++ b/options-admin.php
@@ -67,6 +67,9 @@ function shibboleth_options_page() {
 				if ( ! defined( 'SHIBBOLETH_ATTRIBUTE_ACCESS_METHOD' ) ) {
 					update_site_option( 'shibboleth_attribute_access_method', $_POST['attribute_access'] );
 				}
+				if ( ! defined( 'SHIBBOLETH_ATTRIBUTE_ACCESS_METHOD_FALLBACK' ) ) {
+					update_site_option( 'shibboleth_attribute_access_method_fallback', $_POST['attribute_access_fallback'] );
+				}
 				if ( ! defined( 'SHIBBOLETH_ATTRIBUTE_CUSTOM_ACCESS_METHOD' ) ) {
 					update_site_option( 'shibboleth_attribute_custom_access_method', $_POST['attribute_custom_access'] );
 				}
@@ -201,6 +204,8 @@ function shibboleth_options_page() {
 					$constant = $constant || $from_constant;
 					list( $attribute_access, $from_constant ) = shibboleth_getoption( 'shibboleth_attribute_access_method', false, false, true );
 					$constant = $constant || $from_constant;
+					list( $attribute_access_fallback, $from_constant ) = shibboleth_getoption( 'shibboleth_attribute_access_method_fallback', false, false, true );
+					$constant = $constant || $from_constant;
 					list( $attribute_custom_access, $from_constant ) = shibboleth_getoption( 'shibboleth_attribute_custom_access_method', false, false, true );
 					$constant = $constant || $from_constant;
 					list( $spoofkey, $from_constant ) = shibboleth_getoption( 'shibboleth_spoof_key', false, false, true );
@@ -293,6 +298,16 @@ function shibboleth_options_page() {
 						. '<br /><b>WARNING:</b> If you incorrectly set this option, you will force <b><i>ALL</i></b> attempts to authenticate with Shibboleth to fail.', 'shibboleth'); ?></p>
 					</td>
 				</tr>
+				<tr id="attribute_access_fallback_row" <?php if( $attribute_access === 'standard' ) echo 'style="display:none;"'; ?>>
+				<th scope="row"><label for="attribute_access_fallback"><?php _e('Enable Fallback Attribute Access', 'shibboleth'); ?></label></th>
+					<td>
+						<input type="checkbox" id="attribute_access_fallback" name="attribute_access_fallback" <?php echo $attribute_access_fallback ? ' checked="checked"' : '' ?> <?php if ( defined( 'SHIBBOLETH_ATTRIBUTE_ACCESS_METHOD_FALLBACK' ) ) { disabled( $attribute_access_fallback, SHIBBOLETH_ATTRIBUTE_ACCESS_METHOD_FALLBACK ); } ?> />
+						<label for="attribute_access_fallback"><?php _e('Allow the standard environment variables to be used as a fallback for attribute access.', 'shibboleth'); ?></label>
+
+						<p><?php _e('If set, this will fallback to standard environment variables when the selected'
+							. ' attribute access method fails.', 'shibboleth'); ?></p>
+					</td>
+				</tr>
 				<tr>
 				<th scope="row"><label for="default_login"><?php _e('Default Login Method', 'shibboleth'); ?></label></th>
 					<td>
@@ -357,17 +372,26 @@ function shibboleth_options_page() {
 
 				    if (selectedValue == "custom")
 				    {
-				    	document.getElementById("attribute_custom_access_row").style.display = "table-row";
+						document.getElementById("attribute_custom_access_row").style.display = "table-row";
+						document.getElementById("attribute_access_fallback_row").style.display = "table-row";
 				    	document.getElementById("spoofkey_row").style.display = "none";
 				    }
 				    else if (selectedValue == "http")
 				    {
-				    	document.getElementById("attribute_custom_access_row").style.display = "none";
+						document.getElementById("attribute_custom_access_row").style.display = "none";
+						document.getElementById("attribute_access_fallback_row").style.display = "table-row";
 				    	document.getElementById("spoofkey_row").style.display = "table-row";
+					}
+				    else if (selectedValue == "standard")
+				    {
+						document.getElementById("attribute_custom_access_row").style.display = "none";
+						document.getElementById("attribute_access_fallback_row").style.display = "none";
+						document.getElementById("spoofkey_row").style.display = "none";
 				    }
 				    else
 				    {
-				       document.getElementById("attribute_custom_access_row").style.display = "none";
+					   document.getElementById("attribute_custom_access_row").style.display = "none";
+					   document.getElementById("attribute_access_fallback_row").style.display = "table-row";
 				       document.getElementById("spoofkey_row").style.display = "none";
 				    }
 				}

--- a/options-user.php
+++ b/options-user.php
@@ -26,7 +26,7 @@ add_action( 'personal_options', 'shibboleth_edit_user_options' );
  * For WordPress accounts that were created by Shibboleth, disable certain fields
  * that users/administrators aren't allowed to modify.
  *
- * @since 1.3 (renamed in 2.3 from `shibboleth_admin_footer_edit_user`)
+ * @since 1.3 (renamed in 2.3 from `shibboleth_admin_footer_profile`)
  */
 function shibboleth_disable_managed_fields() {
 	$managed_fields = shibboleth_get_managed_user_fields();

--- a/options-user.php
+++ b/options-user.php
@@ -89,28 +89,28 @@ function shibboleth_prevent_managed_fields_update( $user_id ) {
 
 	if ( get_user_meta( $user_id, 'shibboleth_account' ) ) {
 
-		$user = get_user_by('id', $user_id );
+		$user = get_user_by( 'id', $user_id );
 
 		$managed = shibboleth_get_managed_user_fields();
 
 		if ( in_array( 'first_name', $managed ) ) {
-			$_POST['first_name']=$user->first_name;
+			$_POST['first_name'] = $user->first_name;
 		}
 
 		if ( in_array( 'last_name', $managed ) ) {
-			$_POST['last_name']=$user->last_name;
+			$_POST['last_name'] = $user->last_name;
 		}
 
 		if ( in_array( 'nickname', $managed ) ) {
-			$_POST['nickname']=$user->nickname;
+			$_POST['nickname'] = $user->nickname;
 		}
 
 		if ( in_array( 'display_name', $managed ) ) {
-			$_POST['display_name']=$user->display_name;
+			$_POST['display_name'] = $user->display_name;
 		}
 
 		if ( in_array( 'email', $managed ) ) {
-			$_POST['email']=$user->user_email;
+			$_POST['email'] = $user->user_email;
 		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,10 @@
 === Shibboleth ===
 Contributors: michaelryanmcneill, willnorris, mitchoyoshitaka, jrchamp, dericcrago, bshelton229, Alhrath, dandalpiaz
 Tags: shibboleth, authentication, login, saml
-Requires at least: 3.3
-Tested up to: 5.4.2
-Stable tag: 2.2.2
+Requires at least: 4.0
+Tested up to: 5.5
+Requires PHP: 5.6
+Stable tag: 2.3
 
 Allows WordPress to externalize user authentication and account creation to a Shibboleth Service Provider.
 
@@ -90,6 +91,10 @@ Yes, the plugin allows for all settings to be controlled via constants in `wp-co
    - Format: string
    - Available options: `'standard'` for the default "Environment Variables" option, `'redirect'` for the "Redirected Environment Variables" option, and `'http'` for the "HTTP Headers" option.
    - Example: `define('SHIBBOLETH_ATTRIBUTE_ACCESS_METHOD', 'standard');`
+ - `SHIBBOLETH_ATTRIBUTE_ACCESS_METHOD_FALLBACK`
+   - Format: boolean
+   - Available options: `true` to fallback to the standard "Environment Variables" options when the selected attribute access method does not return results or `false` to not fallback.
+   - Example: `define('SHIBBOLETH_ATTRIBUTE_ACCESS_METHOD_FALLBACK', true);`
  - `SHIBBOLETH_LOGIN_URL`
    - Format: string
    - Avaliable Options: none
@@ -176,6 +181,9 @@ Yes, the plugin allows for all settings to be controlled via constants in `wp-co
 3. Assign users into WordPress roles based on arbitrary data provided by Shibboleth
 
 == Upgrade Notice ==
+= 2.3 =
+This update increases the minimum PHP version to 5.6 and the minimum WordPress version to 4.0. The plugin will fail to activate if you are running below those minimum versions. 
+
 = 2.2.2 =
 This update re-implements a previously reverted <IfModule> conditional for three aliases of the Shibboleth Apache module: `mod_shib`, `mod_shib.c`, and `mod_shib.cpp`. If you run into issues related to this change, please open an issue on [GitHub](https://github.com/michaelryanmcneill/shibboleth/issues).
 
@@ -189,6 +197,12 @@ This update brings with it a major change to the way Shibboleth attributes are a
 This update brings with it a major change to the way Shibboleth attributes are accessed. For most users, no additional configuration will be necessary. If you are using a specialized server configuration, such as a Shibboleth Service Provider on a reverse proxy or a server configuration that results in environment variables being sent with the prefix REDIRECT_, you should see the changelog for additional details: https://wordpress.org/plugins/shibboleth/#developers
 
 == Changelog ==
+= version 2.3 (2020-XX-XX) =
+ - Implementing a fallback option for the "Shibboleth Attribute Access Method". For example, if your web server returns redirected environment variables, but occasionally returns standard environment variables, you would want to enable this option. 
+ - Removing deprecated `create_function()` from use. 
+ - Bumped minimum PHP and WordPress versions to 5.6 and 4.0 respectively. 
+ - Greatly improved the handling of managed fields and cleaned up `options-user.php`.  
+
 = version 2.2.2 (2020-06-22) =
  - Re-implementing <IfModule> conditional for .htaccess to protect against the Shibboleth Apache module not being installed; [thanks to @jrchamp for reporting](https://github.com/michaelryanmcneill/shibboleth/issues/60). This change includes conditionals for `mod_shib`, `mod_shib.c`, and `mod_shib.cpp`. If you run into issues related to this change, please open an issue on [GitHub](https://github.com/michaelryanmcneill/shibboleth/issues).
 

--- a/readme.txt
+++ b/readme.txt
@@ -197,7 +197,7 @@ This update brings with it a major change to the way Shibboleth attributes are a
 This update brings with it a major change to the way Shibboleth attributes are accessed. For most users, no additional configuration will be necessary. If you are using a specialized server configuration, such as a Shibboleth Service Provider on a reverse proxy or a server configuration that results in environment variables being sent with the prefix REDIRECT_, you should see the changelog for additional details: https://wordpress.org/plugins/shibboleth/#developers
 
 == Changelog ==
-= version 2.3 (2020-XX-XX) =
+= version 2.3 (2020-08-17) =
  - Implementing a fallback option for the "Shibboleth Attribute Access Method". For example, if your web server returns redirected environment variables, but occasionally returns standard environment variables, you would want to enable this option. 
  - Removing deprecated `create_function()` from use. 
  - Bumped minimum PHP and WordPress versions to 5.6 and 4.0 respectively. 

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -4,13 +4,16 @@
  Plugin URI: http://wordpress.org/extend/plugins/shibboleth
  Description: Easily externalize user authentication to a <a href="http://shibboleth.internet2.edu">Shibboleth</a> Service Provider
  Author: Michael McNeill, mitcho (Michael 芳貴 Erlewine), Will Norris
- Version: 2.2.2
+ Version: 2.3
+ Requires PHP: 5.6
+ Requires at least: 4.0
  License: Apache 2 (http://www.apache.org/licenses/LICENSE-2.0.html)
  Text Domain: shibboleth
  */
 
-define( 'SHIBBOLETH_MINIMUM_WP_VERSION', '3.3' );
-define( 'SHIBBOLETH_PLUGIN_VERSION', '2.2' );
+define( 'SHIBBOLETH_MINIMUM_WP_VERSION', '4.0' );
+define( 'SHIBBOLETH_MINIMUM_PHP_VERSION', '5.6');
+define( 'SHIBBOLETH_PLUGIN_VERSION', '2.3' );
 
 /**
  * Determine if this is a new install or upgrade and, if so, run the
@@ -79,11 +82,14 @@ function shibboleth_getenv( $var ) {
 	// Get the specified shibboleth attribute access method; if one isn't specified
 	// simply use standard environment variables since they're the safest
 	$method = shibboleth_getoption( 'shibboleth_attribute_access_method', 'standard' );
+	$fallback = shibboleth_getoption( 'shibboleth_attribute_access_method_fallback' );
 
 	switch ( $method ) {
 		// Use standard by default for security
 		case 'standard' :
 			$var_method = '';
+			// Disable fallback to prevent the same variables from being checked twice.
+			$fallback = false;
 			break;
 		// If specified, use redirect
 		case 'redirect' :
@@ -101,6 +107,8 @@ function shibboleth_getenv( $var ) {
 		// Otherwise, fall back to standard for security
 		default :
 			$var_method = '';
+			// Disable fallback to prevent the same variables from being checked twice.
+			$fallback = false;
 	}
 
 	// Using the selected attribute access method, check all possible cases
@@ -114,6 +122,18 @@ function shibboleth_getenv( $var ) {
 		$var_method . $var_upper => TRUE,
 		$var_method . $var_under_upper => TRUE,
 	);
+
+	// If fallback is enabled, we will add the standard environment variables to the end of the array to allow for fallback
+	if ( $fallback ) {
+		$fallback_check_vars = array(
+			$var => TRUE,
+			$var_under => TRUE,
+			$var_upper => TRUE,
+			$var_under_upper => TRUE,
+		);
+
+		array_merge( $check_vars, $fallback_check_vars);
+	}
 
 	foreach ( $check_vars as $check_var => $true ) {
 		if ( isset( $_SERVER[$check_var] ) && ( $result = $_SERVER[$check_var] ) !== FALSE ) {
@@ -155,7 +175,10 @@ add_action( 'init', 'shibboleth_auto_login' );
 function shibboleth_activate_plugin() {
 	if ( version_compare( $GLOBALS['wp_version'], SHIBBOLETH_MINIMUM_WP_VERSION, '<' ) ) {
 		deactivate_plugins( plugin_basename( __FILE__ ) );
-		wp_die( __( 'Shibboleth requires WordPress '. SHIBBOLETH_MINIMUM_WP_VERSION . 'or higher!', 'shibboleth' ) );
+		wp_die( __( 'Shibboleth requires WordPress '. SHIBBOLETH_MINIMUM_WP_VERSION . ' or higher!', 'shibboleth' ) );
+	} elseif ( version_compare( PHP_VERSION, SHIBBOLETH_MINIMUM_PHP_VERSION, '<' ) ) {
+		deactivate_plugins( plugin_basename( __FILE__ ) );
+		wp_die( __( 'Shibboleth requires PHP '. SHIBBOLETH_MINIMUM_PHP_VERSION . ' or higher!', 'shibboleth' ) );
 	}
 
 	if ( function_exists( 'switch_to_blog' ) ) {

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -132,7 +132,7 @@ function shibboleth_getenv( $var ) {
 			$var_under_upper => TRUE,
 		);
 
-		array_merge( $check_vars, $fallback_check_vars);
+		$check_vars = array_merge( $check_vars, $fallback_check_vars );
 	}
 
 	foreach ( $check_vars as $check_var => $true ) {


### PR DESCRIPTION
Changes include:  
- Implementing a fallback option for the "Shibboleth Attribute Access Method". For example, if your web server returns redirected environment variables, but occasionally returns standard environment variables, you would want to enable this option. 
 - Removing deprecated `create_function()` from use. 
 - Bumped minimum PHP and WordPress versions to 5.6 and 4.0 respectively. 
 - Greatly improved the handling of managed fields and cleaned up `options-user.php`.  

Resolves #69 and resolves #70.