### PR TITLE
When "Disable Local Auth" is on, hide pwd field

### DIFF
--- a/shibboleth.php
+++ b/shibboleth.php
@@ -845,9 +845,8 @@ function shibboleth_disable_login_form() {
 	if ( $disable && ! $bypass ) {
 	?>
 		<style type="text/css">
-			.login #loginform p ,
-			.login #loginform .user-pass-wrap
-			{
+			.login #loginform p,
+			.login #loginform .user-pass-wrap {
 				display: none;
 			}
 			<?php if ( ! $password_reset_url ) { ?>

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -845,7 +845,9 @@ function shibboleth_disable_login_form() {
 	if ( $disable && ! $bypass ) {
 	?>
 		<style type="text/css">
-			.login #loginform p {
+			.login #loginform p ,
+			.login #loginform .user-pass-wrap
+			{
 				display: none;
 			}
 			<?php if ( ! $password_reset_url ) { ?>


### PR DESCRIPTION
Previously the password field would continue to
show, even when this setting was enabled.

Closes #75