### PR TITLE
Update "tested up to" WP version.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: michaelryanmcneill, willnorris, mitchoyoshitaka, jrchamp, dericcrago, bshelton229, Alhrath, dandalpiaz
 Tags: shibboleth, authentication, login, saml
 Requires at least: 4.0
-Tested up to: 5.5
+Tested up to: 5.8
 Requires PHP: 5.6
 Stable tag: 2.3
 


### PR DESCRIPTION
I have been using this plugin with no issues for the last several versions of WP Core, and I strongly suspect others have as well. This PR just updates the "Tested up to:" string in readme.txt, which should get rid of the "This plugin hasn't been updated in forever" message on wordpress.org.