### PR TITLE
css: inherit WordPress text color for contrast

### DIFF
--- a/assets/css/shibboleth_login_form.css
+++ b/assets/css/shibboleth_login_form.css
@@ -46,7 +46,6 @@
 }
 
 #loginform #shibboleth-wrap p {
-	color: #777777;
 	margin-bottom: 16px;
 }
 
@@ -87,7 +86,6 @@
 }
 .shibboleth-or span {
 	background: #fff;
-	color: #777;
 	position: relative;
 	padding: 0 8px;
 	text-transform: uppercase


### PR DESCRIPTION
WCAG SC 1.4.3 sets minimum contrast rules for accessibility.

Fixes #83 