### PR TITLE
Fix/WPCS input sanitization and WCAG accessibility

### DIFF
--- a/.github/workflows/wp-plugin-ci-full.yml
+++ b/.github/workflows/wp-plugin-ci-full.yml
@@ -27,4 +27,4 @@ jobs:
 
     - name: Run PHPCS on all files
       run: |
-        vendor/bin/phpcs -q -n --ignore=vendor --runtime-set installed_paths vendor/wp-coding-standards/wpcs --standard=WordPress-Core --report=checkstyle $GITHUB_WORKSPACE | cs2pr
+        vendor/bin/phpcs -q -n --ignore=vendor --runtime-set installed_paths vendor/wp-coding-standards/wpcs --standard=WordPress --report=checkstyle $GITHUB_WORKSPACE | cs2pr

--- a/.github/workflows/wp-plugin-ci.yml
+++ b/.github/workflows/wp-plugin-ci.yml
@@ -32,4 +32,4 @@ jobs:
       run: |
         touch $GITHUB_WORKSPACE/tmp.php
         export CHANGED_FILES=$(git diff --name-only --diff-filter=AM remotes/origin/${{ github.base_ref }} | tr '\n' ' ')
-        vendor/bin/phpcs -q -n --ignore=vendor --runtime-set installed_paths vendor/wp-coding-standards/wpcs --standard=WordPress-Core --report=checkstyle $GITHUB_WORKSPACE/tmp.php $(echo $CHANGED_FILES) | cs2pr
+        vendor/bin/phpcs -q -n --ignore=vendor --runtime-set installed_paths vendor/wp-coding-standards/wpcs --standard=WordPress --report=checkstyle $GITHUB_WORKSPACE/tmp.php $(echo $CHANGED_FILES) | cs2pr

--- a/assets/js/shibboleth_login_form.js
+++ b/assets/js/shibboleth_login_form.js
@@ -1,5 +1,9 @@
-// Originally from Automattic's Jetpack SSO module (v5.3)
-// @see https://github.com/Automattic/jetpack/blob/5.3/modules/sso/jetpack-sso-login.js
+/**
+ * Originally from Automattic's Jetpack SSO module (v5.3)
+ *
+ * @see https://github.com/Automattic/jetpack/blob/5.3/modules/sso/jetpack-sso-login.js.
+ * @package shibboleth
+ */
 
 jQuery( document ).ready(
 	function( $ ) {
@@ -15,7 +19,7 @@ jQuery( document ).ready(
 		// UI under the submit button.
 		//
 		// @TODO: Remove this approach once core ticket 28528 is in and we have more actions in wp-login.php.
-		// See - https://core.trac.wordpress.org/ticket/28528
+		// See - https://core.trac.wordpress.org/ticket/28528.
 		loginForm.append( overflow );
 		overflow.append( $( 'p.forgetmenot' ), $( 'p.submit' ) );
 

--- a/options-admin.php
+++ b/options-admin.php
@@ -265,8 +265,8 @@ function shibboleth_options_page() {
 						);
 						?>
 						<br /><?php esc_html_e( 'Wiki Documentation', 'shibboleth' ); ?>:
-						<a href="https://spaces.internet2.edu/display/SHIB/SessionInitiator" target="_blank">Shibboleth 1.3</a> |
-						<a href="https://spaces.internet2.edu/display/SHIB2/NativeSPSessionInitiator" target="_blank">Shibboleth 2</a>
+						<a href="https://shibboleth.atlassian.net/wiki/spaces/SP3/pages/2065334685/SessionInitiator" target="_blank">Shibboleth SP v3</a> |
+						<a href="https://shibboleth.atlassian.net/wiki/spaces/SHIB2/pages/2577072500/NativeSPSessionInitiator" target="_blank">Shibboleth SP v2</a>
 					</td>
 				</tr>
 				<tr valign="top">
@@ -283,8 +283,8 @@ function shibboleth_options_page() {
 						);
 						?>
 						<br /><?php esc_html_e( 'Wiki Documentation', 'shibboleth' ); ?>:
-						<a href="https://spaces.internet2.edu/display/SHIB/SPMainConfig" target="_blank">Shibboleth 1.3</a> |
-						<a href="https://spaces.internet2.edu/display/SHIB2/NativeSPLogoutInitiator" target="_blank">Shibboleth 2</a>
+						<a href="https://shibboleth.atlassian.net/wiki/spaces/SP3/pages/2065334687/LogoutInitiator" target="_blank">Shibboleth SP v3</a> |
+						<a href="https://shibboleth.atlassian.net/wiki/spaces/SHIB2/pages/2577072384/NativeSPLogoutInitiator" target="_blank">Shibboleth SP v2</a>
 					</td>
 				</tr>
 				<tr valign="top">

--- a/options-admin.php
+++ b/options-admin.php
@@ -89,19 +89,19 @@ function shibboleth_options_page() {
 					update_site_option( 'shibboleth_attribute_custom_access_method', sanitize_text_field( wp_unslash( $_POST['attribute_custom_access'] ) ) );
 				}
 				if ( ! defined( 'SHIBBOLETH_LOGIN_URL' ) && isset( $_POST['login_url'] ) ) {
-					update_site_option( 'shibboleth_login_url', sanitize_url( wp_unslash( $_POST['login_url'] ) ) );
+					update_site_option( 'shibboleth_login_url', esc_url_raw( wp_unslash( $_POST['login_url'] ) ) );
 				}
 				if ( ! defined( 'SHIBBOLETH_LOGOUT_URL' ) && isset( $_POST['logout_url'] ) ) {
-					update_site_option( 'shibboleth_logout_url', sanitize_url( wp_unslash( $_POST['logout_url'] ) ) );
+					update_site_option( 'shibboleth_logout_url', esc_url_raw( wp_unslash( $_POST['logout_url'] ) ) );
 				}
 				if ( ! defined( 'SHIBBOLETH_SPOOF_KEY' ) && isset( $_POST['spoofkey'] ) ) {
 					update_site_option( 'shibboleth_spoof_key', sanitize_text_field( wp_unslash( $_POST['spoofkey'] ) ) );
 				}
 				if ( ! defined( 'SHIBBOLETH_PASSWORD_CHANGE_URL' ) && isset( $_POST['password_change_url'] ) ) {
-					update_site_option( 'shibboleth_password_change_url', sanitize_url( wp_unslash( $_POST['password_change_url'] ) ) );
+					update_site_option( 'shibboleth_password_change_url', esc_url_raw( wp_unslash( $_POST['password_change_url'] ) ) );
 				}
 				if ( ! defined( 'SHIBBOLETH_PASSWORD_RESET_URL' ) && isset( $_POST['password_reset_url'] ) ) {
-					update_site_option( 'shibboleth_password_reset_url', sanitize_url( wp_unslash( $_POST['password_reset_url'] ) ) );
+					update_site_option( 'shibboleth_password_reset_url', esc_url_raw( wp_unslash( $_POST['password_reset_url'] ) ) );
 				}
 				if ( ! defined( 'SHIBBOLETH_DEFAULT_TO_SHIB_LOGIN' ) ) {
 					update_site_option( 'shibboleth_default_to_shib_login', ! empty( $_POST['default_login'] ) );

--- a/options-admin.php
+++ b/options-admin.php
@@ -19,12 +19,12 @@ function shibboleth_admin_tabs( $current = 'general' ) {
 		'authorization' => 'Authorization',
 		'logging' => 'Logging',
 	);
-	echo '<h2 class="nav-tab-wrapper">';
+	echo '<nav class="nav-tab-wrapper">';
 	foreach ( $tabs as $tab => $name ) {
 		$class = ( $tab === $current ) ? ' nav-tab-active' : '';
 		echo '<a class="nav-tab' . esc_attr( $class ) . '" href="?page=shibboleth-options&tab=' . esc_attr( $tab ) . '">' . esc_html( $name ) . '</a>';
 	}
-	echo '</h2>';
+	echo '</nav>';
 }
 
 /**
@@ -232,7 +232,7 @@ function shibboleth_options_page() {
 					$constant = $constant || $from_constant;
 					?>
 
-			<h3><?php esc_html_e( 'General Configuration', 'shibboleth' ); ?></h3>
+			<h2><?php esc_html_e( 'General Configuration', 'shibboleth' ); ?></h2>
 					<?php if ( $constant ) { ?>
 				<div class="notice notice-warning">
 					<p><?php echo wp_kses_post( __( '<strong>Note:</strong> Some options below are defined in the <code>wp-config.php</code> file as constants and cannot be modified from this page.', 'shibboleth' ) ); ?></p>
@@ -348,7 +348,7 @@ function shibboleth_options_page() {
 					</td>
 				</tr>
 				<tr id="attribute_access_fallback_row" <?php echo 'standard' === $attribute_access ? 'style="display:none;"' : ''; ?>>
-					<th scope="row"><label for="attribute_access_fallback"><?php esc_html_e( 'Enable Fallback Attribute Access', 'shibboleth' ); ?></label></th>
+					<th scope="row"><?php esc_html_e( 'Enable Fallback Attribute Access', 'shibboleth' ); ?></th>
 					<td>
 						<input type="checkbox" id="attribute_access_fallback" name="attribute_access_fallback" <?php checked( (bool) $attribute_access_fallback ); ?> <?php defined( 'SHIBBOLETH_ATTRIBUTE_ACCESS_METHOD_FALLBACK' ) && disabled( $attribute_access_fallback, SHIBBOLETH_ATTRIBUTE_ACCESS_METHOD_FALLBACK ); ?> />
 						<label for="attribute_access_fallback"><?php esc_html_e( 'Allow the standard environment variables to be used as a fallback for attribute access.', 'shibboleth' ); ?></label>
@@ -365,7 +365,7 @@ function shibboleth_options_page() {
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="default_login"><?php esc_html_e( 'Default Login Method', 'shibboleth' ); ?></label></th>
+					<th scope="row"><?php esc_html_e( 'Default Login Method', 'shibboleth' ); ?></th>
 					<td>
 						<input type="checkbox" id="default_login" name="default_login" <?php checked( (bool) $default_login ); ?> <?php defined( 'SHIBBOLETH_DEFAULT_TO_SHIB_LOGIN' ) && disabled( $default_login, SHIBBOLETH_DEFAULT_TO_SHIB_LOGIN ); ?> />
 						<label for="default_login"><?php esc_html_e( 'Use Shibboleth as the default login method for users.', 'shibboleth' ); ?></label>
@@ -383,7 +383,7 @@ function shibboleth_options_page() {
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="auto_login"><?php esc_html_e( 'Automatic Login', 'shibboleth' ); ?></label></th>
+					<th scope="row"><?php esc_html_e( 'Automatic Login', 'shibboleth' ); ?></th>
 					<td>
 						<input type="checkbox" id="auto_login" name="auto_login" <?php checked( (bool) $auto_login ); ?> <?php defined( 'SHIBBOLETH_AUTO_LOGIN' ) && disabled( $auto_login, SHIBBOLETH_AUTO_LOGIN ); ?> />
 						<label for="auto_login"><?php esc_html_e( 'Use Shibboleth to auto-login users.', 'shibboleth' ); ?></label>
@@ -402,7 +402,7 @@ function shibboleth_options_page() {
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="disable_local_auth"><?php esc_html_e( 'Disable Local Authentication', 'shibboleth' ); ?></label></th>
+					<th scope="row"><?php esc_html_e( 'Disable Local Authentication', 'shibboleth' ); ?></th>
 					<td>
 						<input type="checkbox" id="disable_local_auth" name="disable_local_auth" <?php checked( (bool) $disable_local_auth ); ?> <?php defined( 'SHIBBOLETH_DISABLE_LOCAL_AUTH' ) && disabled( $disable_local_auth, SHIBBOLETH_DISABLE_LOCAL_AUTH ); ?> />
 						<label for="disable_local_auth"><?php esc_html_e( 'Disables local WordPress authentication.', 'shibboleth' ); ?></label>
@@ -491,7 +491,7 @@ function shibboleth_options_page() {
 					<p><?php echo wp_kses_post( __( '<strong>Note:</strong> Some options below are defined in the <code>wp-config.php</code> file as constants and cannot be modified from this page.', 'shibboleth' ) ); ?></p>
 				</div>
 			<?php } ?>
-			<h4><?php esc_html_e( 'User Profile Data', 'shibboleth' ); ?></h4>
+			<h3><?php esc_html_e( 'User Profile Data', 'shibboleth' ); ?></h3>
 
 			<p>
 					<?php
@@ -519,7 +519,7 @@ function shibboleth_options_page() {
 						<input type="text" id="username" name="headers[username][name]" value="<?php echo esc_attr( $shib_headers['username']['name'] ); ?>" <?php disabled( $shib_headers_constant ); ?>/>
 					</td>
 					<td width="60%">
-						<input type="checkbox" id="username_managed" name="headers[username][managed]" <?php checked( true ); ?><?php disabled( true ); ?>/> <?php esc_html_e( 'Managed', 'shibboleth' ); ?>
+						<input type="checkbox" id="username_managed" name="headers[username][managed]" <?php checked( true ); ?><?php disabled( true ); ?>/> <label for="username_managed"><?php esc_html_e( 'Managed', 'shibboleth' ); ?></label>
 					</td>
 				</tr>
 				<tr valign="top">
@@ -528,7 +528,7 @@ function shibboleth_options_page() {
 						<input type="text" id="first_name" name="headers[first_name][name]" value="<?php echo esc_attr( $shib_headers['first_name']['name'] ); ?>" <?php disabled( $shib_headers_constant ); ?>/>
 					</td>
 					<td>
-						<input type="checkbox" id="first_name_managed" name="headers[first_name][managed]" <?php isset( $shib_headers['first_name']['managed'] ) && checked( $shib_headers['first_name']['managed'], 'on' ); ?><?php disabled( $shib_headers_constant ); ?> /> <?php esc_html_e( 'Managed', 'shibboleth' ); ?>
+						<input type="checkbox" id="first_name_managed" name="headers[first_name][managed]" <?php isset( $shib_headers['first_name']['managed'] ) && checked( $shib_headers['first_name']['managed'], 'on' ); ?><?php disabled( $shib_headers_constant ); ?> /> <label for="first_name_managed"><?php esc_html_e( 'Managed', 'shibboleth' ); ?></label>
 					</td>
 				</tr>
 				<tr valign="top">
@@ -537,7 +537,7 @@ function shibboleth_options_page() {
 						<input type="text" id="last_name" name="headers[last_name][name]" value="<?php echo esc_attr( $shib_headers['last_name']['name'] ); ?>" <?php disabled( $shib_headers_constant ); ?>/>
 					</td>
 					<td>
-						<input type="checkbox" id="last_name_managed" name="headers[last_name][managed]" <?php isset( $shib_headers['last_name']['managed'] ) && checked( $shib_headers['last_name']['managed'], 'on' ); ?><?php disabled( $shib_headers_constant ); ?> /> <?php esc_html_e( 'Managed', 'shibboleth' ); ?>
+						<input type="checkbox" id="last_name_managed" name="headers[last_name][managed]" <?php isset( $shib_headers['last_name']['managed'] ) && checked( $shib_headers['last_name']['managed'], 'on' ); ?><?php disabled( $shib_headers_constant ); ?> /> <label for="last_name_managed"><?php esc_html_e( 'Managed', 'shibboleth' ); ?></label>
 					</td>
 				</tr>
 				<tr valign="top">
@@ -546,7 +546,7 @@ function shibboleth_options_page() {
 						<input type="text" id="nickname" name="headers[nickname][name]" value="<?php echo esc_attr( $shib_headers['nickname']['name'] ); ?>" <?php disabled( $shib_headers_constant ); ?>/>
 					</td>
 					<td>
-						<input type="checkbox" id="nickname_managed" name="headers[nickname][managed]" <?php isset( $shib_headers['nickname']['managed'] ) && checked( $shib_headers['nickname']['managed'], 'on' ); ?><?php disabled( $shib_headers_constant ); ?>/> <?php esc_html_e( 'Managed', 'shibboleth' ); ?>
+						<input type="checkbox" id="nickname_managed" name="headers[nickname][managed]" <?php isset( $shib_headers['nickname']['managed'] ) && checked( $shib_headers['nickname']['managed'], 'on' ); ?><?php disabled( $shib_headers_constant ); ?>/> <label for="nickname_managed"><?php esc_html_e( 'Managed', 'shibboleth' ); ?></label>
 					</td>
 				</tr>
 				<tr valign="top">
@@ -555,7 +555,7 @@ function shibboleth_options_page() {
 						<input type="text" id="_display_name" name="headers[display_name][name]" value="<?php echo esc_attr( $shib_headers['display_name']['name'] ); ?>" <?php disabled( $shib_headers_constant ); ?>/>
 					</td>
 					<td>
-						<input type="checkbox" id="display_name_managed" name="headers[display_name][managed]" <?php isset( $shib_headers['display_name']['managed'] ) && checked( $shib_headers['display_name']['managed'], 'on' ); ?><?php disabled( $shib_headers_constant ); ?>/> <?php esc_html_e( 'Managed', 'shibboleth' ); ?>
+						<input type="checkbox" id="display_name_managed" name="headers[display_name][managed]" <?php isset( $shib_headers['display_name']['managed'] ) && checked( $shib_headers['display_name']['managed'], 'on' ); ?><?php disabled( $shib_headers_constant ); ?>/> <label for="display_name_managed"><?php esc_html_e( 'Managed', 'shibboleth' ); ?></label>
 					</td>
 				</tr>
 				<tr valign="top">
@@ -564,7 +564,7 @@ function shibboleth_options_page() {
 						<input type="text" id="email" name="headers[email][name]" value="<?php echo esc_attr( $shib_headers['email']['name'] ); ?>" <?php disabled( $shib_headers_constant ); ?>/>
 					</td>
 					<td>
-						<input type="checkbox" id="email_managed" name="headers[email][managed]" <?php isset( $shib_headers['email']['managed'] ) && checked( $shib_headers['email']['managed'], 'on' ); ?><?php disabled( $shib_headers_constant ); ?> /> <?php esc_html_e( 'Managed', 'shibboleth' ); ?>
+						<input type="checkbox" id="email_managed" name="headers[email][managed]" <?php isset( $shib_headers['email']['managed'] ) && checked( $shib_headers['email']['managed'], 'on' ); ?><?php disabled( $shib_headers_constant ); ?> /> <label for="email_managed"><?php esc_html_e( 'Managed', 'shibboleth' ); ?></label>
 					</td>
 				</tr>
 			</table>
@@ -585,7 +585,7 @@ function shibboleth_options_page() {
 
 			<table class="form-table">
 				<tr valign="top">
-					<th scope="row"><label for="create_accounts"><?php esc_html_e( 'Automatically Create Accounts', 'shibboleth' ); ?></label></th>
+					<th scope="row"><?php esc_html_e( 'Automatically Create Accounts', 'shibboleth' ); ?></th>
 					<td>
 						<input type="checkbox" id="create_accounts" name="create_accounts" <?php checked( (bool) $create_accounts ); ?> <?php defined( 'SHIBBOLETH_CREATE_ACCOUNTS' ) && disabled( $create_accounts, SHIBBOLETH_CREATE_ACCOUNTS ); ?> />
 						<label for="create_accounts"><?php esc_html_e( 'Automatically create new users if they do not exist in the WordPress database.', 'shibboleth' ); ?></label>
@@ -628,7 +628,7 @@ function shibboleth_options_page() {
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="manually_combine_accounts"></label></th>
+					<th scope="row"><label for="manually_combine_accounts"><?php esc_html_e( 'Manual Account Merging', 'shibboleth' ); ?></label></th>
 					<td>
 						<select id="manually_combine_accounts" name="manually_combine_accounts" <?php defined( 'SHIBBOLETH_MANUALLY_COMBINE_ACCOUNTS' ) && disabled( $manually_combine_accounts, SHIBBOLETH_MANUALLY_COMBINE_ACCOUNTS ); ?>>
 							<option value="prevent" <?php selected( $manually_combine_accounts, 'disallow' ); ?>>Prevent Manual Account Merging</option>
@@ -666,7 +666,7 @@ function shibboleth_options_page() {
 					$constant = $constant || $from_constant;
 					?>
 
-			<h3><?php esc_html_e( 'User Role Mappings', 'shibboleth' ); ?></h3>
+			<h2><?php esc_html_e( 'User Role Mappings', 'shibboleth' ); ?></h2>
 						<?php if ( $constant ) { ?>
 				<div class="notice notice-warning">
 					<p><?php echo wp_kses_post( __( '<strong>Note:</strong> Some options below are defined in the <code>wp-config.php</code> file as constants and cannot be modified from this page.', 'shibboleth' ) ); ?></p>
@@ -722,22 +722,19 @@ function shibboleth_options_page() {
 				#role_mappings td, #role_mappings th { border-bottom: 0px; }
 			</style>
 
-			<table class="form-table optiontable editform" cellspacing="2" cellpadding="5" width="100%">
-				<tr>
-					<th scope="row"><?php esc_html_e( 'Role Mappings', 'shibboleth' ); ?></th>
-					<td id="role_mappings">
-						<table id="">
-						<col width="10%"></col>
-						<col></col>
-						<col></col>
-						<thead>
-							<tr>
-								<th></th>
-								<th scope="column"><?php esc_html_e( 'Header Name', 'shibboleth' ); ?></th>
-								<th scope="column"><?php esc_html_e( 'Header Value', 'shibboleth' ); ?></th>
-							</tr>
-						</thead>
-						<tbody>
+			<h3><?php esc_html_e( 'Role Mappings', 'shibboleth' ); ?></h3>
+			<table id="role_mappings" class="form-table optiontable editform" cellspacing="2" cellpadding="5" width="100%">
+				<col width="10%"></col>
+				<col></col>
+				<col></col>
+				<thead>
+					<tr>
+						<th scope="col"><?php esc_html_e( 'Role' ); ?></th>
+						<th scope="col"><?php esc_html_e( 'Header Name', 'shibboleth' ); ?></th>
+						<th scope="col"><?php esc_html_e( 'Header Value', 'shibboleth' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
 							<?php
 
 							foreach ( $wp_roles->role_names as $key => $name ) {
@@ -750,21 +747,20 @@ function shibboleth_options_page() {
 									$value = $shib_roles[ $key ]['value'];
 								}
 								echo '
-						<tr valign="top">
-							<th scope="row">' . esc_html( $name ) . '</th>
-							<td><input type="text" id="role_' . esc_attr( $key ) . '_header" name="shibboleth_roles[' . esc_attr( $key ) . '][header]" value="' . esc_attr( $header ) . '" style="width: 100%" ' . disabled( $shib_roles_constant, true, false ) . '/></td>
-							<td><input type="text" id="role_' . esc_attr( $key ) . '_value" name="shibboleth_roles[' . esc_attr( $key ) . '][value]" value="' . esc_attr( $value ) . '" style="width: 100%" ' . disabled( $shib_roles_constant, true, false ) . '/></td>
-						</tr>';
+				<tr valign="top">
+					<th scope="row">' . esc_html( $name ) . '</th>
+					<td><input type="text" id="role_' . esc_attr( $key ) . '_header" name="shibboleth_roles[' . esc_attr( $key ) . '][header]" value="' . esc_attr( $header ) . '" style="width: 100%" ' . disabled( $shib_roles_constant, true, false ) . '/></td>
+					<td><input type="text" id="role_' . esc_attr( $key ) . '_value" name="shibboleth_roles[' . esc_attr( $key ) . '][value]" value="' . esc_attr( $value ) . '" style="width: 100%" ' . disabled( $shib_roles_constant, true, false ) . '/></td>
+				</tr>';
 							}
 							?>
 
-						</tbody>
-						</table>
-					</td>
-				</tr>
+				</tbody>
+			</table>
 
+			<table class="form-table optiontable editform" cellspacing="2" cellpadding="5" width="100%">
 				<tr>
-					<th scope="row"><?php esc_html_e( 'Default Role', 'shibboleth' ); ?></th>
+					<th scope="row"><label for="default_role"><?php esc_html_e( 'Default Role', 'shibboleth' ); ?></label></th>
 					<td>
 						<select id="default_role" name="default_role" <?php defined( 'SHIBBOLETH_DEFAULT_ROLE' ) && disabled( $default_role, SHIBBOLETH_DEFAULT_ROLE ); ?>>
 							<option value=""><?php esc_html_e( '(no role)', 'shibboleth' ); ?></option>
@@ -792,7 +788,7 @@ function shibboleth_options_page() {
 				</tr>
 
 				<tr>
-					<th scope="row"><label for="update_roles"><?php esc_html_e( 'Update User Roles', 'shibboleth' ); ?></label></th>
+					<th scope="row"><?php esc_html_e( 'Update User Roles', 'shibboleth' ); ?></th>
 					<td>
 						<input type="checkbox" id="update_roles" name="update_roles" <?php checked( (bool) $update_roles ); ?> <?php defined( 'SHIBBOLETH_UPDATE_ROLES' ) && disabled( $update_roles, SHIBBOLETH_UPDATE_ROLES ); ?>
 							/>
@@ -834,7 +830,7 @@ function shibboleth_options_page() {
 					list( $shib_logging, $shib_logging_constant ) = shibboleth_getoption( 'shibboleth_logging', array(), true, true );
 					$constant = $constant || $shib_logging_constant;
 					?>
-		<h3><?php esc_html_e( 'Logging Configuration', 'shibboleth' ); ?></h3>
+		<h2><?php esc_html_e( 'Logging Configuration', 'shibboleth' ); ?></h2>
 					<?php if ( $constant ) { ?>
 			<div class="notice notice-warning">
 				<p><?php echo wp_kses_post( __( '<strong>Note:</strong> Some options below are defined in the <code>wp-config.php</code> file as constants and cannot be modified from this page.', 'shibboleth' ) ); ?></p>
@@ -842,28 +838,28 @@ function shibboleth_options_page() {
 		<?php } ?>
 			<table class="form-table">
 				<tr>
-					<th scope="row"><label for="log_auth"><?php esc_html_e( 'Log Authentication Attempts', 'shibboleth' ); ?></label></th>
+					<th scope="row"><?php esc_html_e( 'Log Authentication Attempts', 'shibboleth' ); ?></th>
 					<td>
 						<input type="checkbox" id="log_auth" name="logging[]" value="auth" <?php checked( in_array( 'auth', $shib_logging, true ) ); ?> <?php defined( $shib_logging_constant ) && disabled( $shib_logging_constant, true, false ); ?> />
 						<label for="log_auth"><?php esc_html_e( 'Log when a user attempts to authenticate using Shibboleth.', 'shibboleth' ); ?></label>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="log_account_merge"><?php esc_html_e( 'Log Account Merges', 'shibboleth' ); ?></label></th>
+					<th scope="row"><?php esc_html_e( 'Log Account Merges', 'shibboleth' ); ?></th>
 					<td>
 						<input type="checkbox" id="log_account_merge" name="logging[]" value="account_merge" <?php checked( in_array( 'account_merge', $shib_logging, true ) ); ?> <?php defined( $shib_logging_constant ) && disabled( $shib_logging_constant, true, false ); ?> />
 						<label for="log_account_merge"><?php esc_html_e( 'Log when a user attempts to merge their account, either manually or automatically.', 'shibboleth' ); ?></label>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="log_account_create"><?php esc_html_e( 'Log Account Creation', 'shibboleth' ); ?></label></th>
+					<th scope="row"><?php esc_html_e( 'Log Account Creation', 'shibboleth' ); ?></th>
 					<td>
 						<input type="checkbox" id="log_account_create" name="logging[]" value="account_create" <?php checked( in_array( 'account_create', $shib_logging, true ) ); ?> <?php defined( $shib_logging_constant ) && disabled( $shib_logging_constant, true, false ); ?> />
 						<label for="log_account_create"><?php esc_html_e( 'Log when new accounts are created.', 'shibboleth' ); ?></label>
 					</td>
 				</tr>
 				<tr>
-					<th scope="row"><label for="log_role_update"><?php esc_html_e( 'Log Role Update', 'shibboleth' ); ?></label></th>
+					<th scope="row"><?php esc_html_e( 'Log Role Update', 'shibboleth' ); ?></th>
 					<td>
 						<input type="checkbox" id="log_role_update" name="logging[]" value="role_update" <?php checked( in_array( 'role_update', $shib_logging, true ) ); ?> <?php defined( $shib_logging_constant ) && disabled( $shib_logging_constant, true, false ); ?> />
 						<label for="log_role_update"><?php esc_html_e( 'Log when the plugin updates a user\'s role.', 'shibboleth' ); ?></label>

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: michaelryanmcneill, willnorris, mitchoyoshitaka, jrchamp, dericcrago, bshelton229, Alhrath, dandalpiaz
 Tags: shibboleth, authentication, login, saml
 Requires at least: 4.0
-Tested up to: 6.1
+Tested up to: 6.2
 Requires PHP: 5.6
-Stable tag: 2.4.1
+Stable tag: 2.4.2
 
 Allows WordPress to externalize user authentication and account creation to a Shibboleth Service Provider.
 
@@ -197,6 +197,12 @@ This update brings with it a major change to the way Shibboleth attributes are a
 This update brings with it a major change to the way Shibboleth attributes are accessed. For most users, no additional configuration will be necessary. If you are using a specialized server configuration, such as a Shibboleth Service Provider on a reverse proxy or a server configuration that results in environment variables being sent with the prefix REDIRECT_, you should see the changelog for additional details: https://wordpress.org/plugins/shibboleth/#developers
 
 == Changelog ==
+= version 2.4.2 (2023-04-07) =
+ - Documentation: Updated Shibboleth documentation external links [#92](https://github.com/michaelryanmcneill/shibboleth/pull/92)
+ - Accessibility: Improve labels and heading structure on admin pages [#92](https://github.com/michaelryanmcneill/shibboleth/pull/92)
+ - Security: Improve input sanitization and use of nonces [#92](https://github.com/michaelryanmcneill/shibboleth/pull/92)
+ - CI: Switch GitHub Action workflows to check against WordPress coding standard [#92](https://github.com/michaelryanmcneill/shibboleth/pull/92)
+
 = version 2.4.1 (2023-03-20) =
  - Compatibility: Fix redirect_to issues on WordPress 6; thanks @masteradhoc, @caosborne89, @jakeparis [#88](https://github.com/michaelryanmcneill/shibboleth/pull/88)
  - Accessibility: Improve color contrast on login page [#89](https://github.com/michaelryanmcneill/shibboleth/pull/89)

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -426,7 +426,7 @@ function shibboleth_authenticate( $user, $username, $password ) {
 		return shibboleth_authenticate_user();
 	} else {
 		if ( isset( $_REQUEST['redirect_to'] ) ) {
-			$redirect_to = sanitize_url( wp_unslash( $_REQUEST['redirect_to'] ) );
+			$redirect_to = esc_url_raw( wp_unslash( $_REQUEST['redirect_to'] ) );
 			$initiator_url = shibboleth_session_initiator_url( $redirect_to );
 		} else {
 			$initiator_url = shibboleth_session_initiator_url();

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -9,7 +9,7 @@
  * Plugin URI: https://wordpress.org/plugins/shibboleth/
  * Description: Easily externalize user authentication to a <a href="https://www.incommon.org/software/shibboleth/">Shibboleth</a> Service Provider
  * Author: Michael McNeill, mitcho (Michael 芳貴 Erlewine), Will Norris
- * Version: 2.4.1
+ * Version: 2.4.2
  * Requires PHP: 5.6
  * Requires at least: 4.0
  * License: Apache 2 (https://www.apache.org/licenses/LICENSE-2.0.html)
@@ -18,7 +18,7 @@
 
 define( 'SHIBBOLETH_MINIMUM_WP_VERSION', '4.0' );
 define( 'SHIBBOLETH_MINIMUM_PHP_VERSION', '5.6' );
-define( 'SHIBBOLETH_PLUGIN_VERSION', '2.4.1' );
+define( 'SHIBBOLETH_PLUGIN_VERSION', '2.4.2' );
 
 /**
  * Determine if this is a new install or upgrade and, if so, run the

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -42,23 +42,23 @@ if ( SHIBBOLETH_PLUGIN_VERSION !== $plugin_version ) {
  *
  * @since 2.1
  * @param string $option Option identifier.
- * @param bool $default Default value.
- * @param bool $array If we expect the value to be an array.
- * @param bool $compact If you want the constant and value returned as an array.
+ * @param bool   $default Default value.
+ * @param bool   $array If we expect the value to be an array.
+ * @param bool   $compact If you want the constant and value returned as an array.
  * @return mixed
  */
 function shibboleth_getoption( $option, $default = false, $array = false, $compact = false ) {
-	// If a constant is defined with the provided option name, get the value of the constant
+	// If a constant is defined with the provided option name, get the value of the constant.
 	if ( defined( strtoupper( $option ) ) ) {
 		$value = constant( strtoupper( $option ) );
 		$constant = true;
 	} else {
-		// If no constant is set, just get the value from get_site_option()
+		// If no constant is set, just get the value from get_site_option().
 		$value = get_site_option( $option, $default );
 		$constant = false;
 	}
 
-	// If compact is set to true, we compact $value and $constant together for easy use
+	// If compact is set to true, we compact $value and $constant together for easy use.
 	if ( $compact ) {
 		return array(
 			$value,
@@ -66,7 +66,7 @@ function shibboleth_getoption( $option, $default = false, $array = false, $compa
 			'value' => $value,
 			'constant' => $constant,
 		);
-		// Otherwise, just return the $value
+		// Otherwise, just return the $value.
 	} else {
 		return $value;
 	}
@@ -84,38 +84,38 @@ function shibboleth_getoption( $option, $default = false, $array = false, $compa
  */
 function shibboleth_getenv( $var ) {
 	// Get the specified shibboleth attribute access method; if one isn't specified
-	// simply use standard environment variables since they're the safest
+	// simply use standard environment variables since they're the safest.
 	$method = shibboleth_getoption( 'shibboleth_attribute_access_method', 'standard' );
 	$fallback = shibboleth_getoption( 'shibboleth_attribute_access_method_fallback' );
 
 	switch ( $method ) {
-		// Use standard by default for security
+		// Use standard by default for security.
 		case 'standard':
 			$var_method = '';
 			// Disable fallback to prevent the same variables from being checked twice.
 			$fallback = false;
 			break;
-		// If specified, use redirect
+		// If specified, use redirect.
 		case 'redirect':
 			$var_method = 'REDIRECT_';
 			break;
-		// If specified, use http
+		// If specified, use http.
 		case 'http':
 			$var_method = 'HTTP_';
 			break;
-		// If specified, use the custom specified method
+		// If specified, use the custom specified method.
 		case 'custom':
 			$custom = shibboleth_getoption( 'shibboleth_attribute_custom_access_method', '' );
 			$var_method = $custom;
 			break;
-		// Otherwise, fall back to standard for security
+		// Otherwise, fall back to standard for security.
 		default:
 			$var_method = '';
 			// Disable fallback to prevent the same variables from being checked twice.
 			$fallback = false;
 	}
 
-	// Using the selected attribute access method, check all possible cases
+	// Using the selected attribute access method, check all possible cases.
 	$var_under = str_replace( '-', '_', $var );
 	$var_upper = strtoupper( $var );
 	$var_under_upper = strtoupper( $var_under );
@@ -127,7 +127,7 @@ function shibboleth_getenv( $var ) {
 		$var_method . $var_under_upper => true,
 	);
 
-	// If fallback is enabled, we will add the standard environment variables to the end of the array to allow for fallback
+	// If fallback is enabled, we will add the standard environment variables to the end of the array to allow for fallback.
 	if ( $fallback ) {
 		$fallback_check_vars = array(
 			$var => true,
@@ -141,7 +141,7 @@ function shibboleth_getenv( $var ) {
 
 	foreach ( $check_vars as $check_var => $true ) {
 		if ( isset( $_SERVER[ $check_var ] ) && false !== $_SERVER[ $check_var ] ) {
-			return $_SERVER[ $check_var ];
+			return sanitize_text_field( wp_unslash( $_SERVER[ $check_var ] ) );
 		}
 	}
 
@@ -162,7 +162,7 @@ function shibboleth_auto_login() {
 
 		$userobj = wp_signon( '', true );
 		if ( ! is_wp_error( $userobj ) ) {
-			wp_safe_redirect( $_SERVER['REQUEST_URI'] );
+			wp_safe_redirect( isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '' );
 			exit();
 		}
 	}
@@ -358,8 +358,8 @@ function shibboleth_migrate_old_data() {
  */
 function shibboleth_admin_hooks() {
 	if ( defined( 'WP_ADMIN' ) && WP_ADMIN === true ) {
-		require_once dirname( __FILE__ ) . '/options-admin.php';
-		require_once dirname( __FILE__ ) . '/options-user.php';
+		require_once __DIR__ . '/options-admin.php';
+		require_once __DIR__ . '/options-user.php';
 	}
 }
 add_action( 'init', 'shibboleth_admin_hooks' );
@@ -418,15 +418,16 @@ function shibboleth_session_active( $auto_login = false ) {
  *
  * @since 1.0
  * @param null|WP_User|WP_Error $user WP_User if the user is authenticated. WP_Error or null otherwise.
- * @param string $username Username or email address.
- * @param string $password User password.
+ * @param string                $username Username or email address.
+ * @param string                $password User password.
  */
 function shibboleth_authenticate( $user, $username, $password ) {
 	if ( shibboleth_session_active() ) {
 		return shibboleth_authenticate_user();
 	} else {
 		if ( isset( $_REQUEST['redirect_to'] ) ) {
-			$initiator_url = shibboleth_session_initiator_url( $_REQUEST['redirect_to'] );
+			$redirect_to = sanitize_url( wp_unslash( $_REQUEST['redirect_to'] ) );
+			$initiator_url = shibboleth_session_initiator_url( $redirect_to );
 		} else {
 			$initiator_url = shibboleth_session_initiator_url();
 		}
@@ -515,7 +516,7 @@ add_action( 'wp_logout', 'shibboleth_logout', 20 );
 function shibboleth_session_initiator_url( $redirect = null ) {
 
 	// first build the target URL.  This is the WordPress URL the user will be returned to after Shibboleth
-	// is done, and will handle actually logging the user into WordPress using the data provided by Shibboleth
+	// is done, and will handle actually logging the user into WordPress using the data provided by Shibboleth.
 	if ( function_exists( 'switch_to_blog' ) ) {
 		if ( ! empty( $GLOBALS['current_blog']->blog_id ) && $GLOBALS['current_blog']->blog_id !== $GLOBALS['current_site']->site_id ) {
 			switch_to_blog( $GLOBALS['current_blog']->blog_id );
@@ -535,7 +536,7 @@ function shibboleth_session_initiator_url( $redirect = null ) {
 		$target = add_query_arg( 'redirect_to', rawurlencode( $redirect ), $target );
 	}
 
-	// now build the Shibboleth session initiator URL
+	// now build the Shibboleth session initiator URL.
 	$initiator_url = shibboleth_getoption( 'shibboleth_login_url' );
 
 	$initiator_url = add_query_arg( 'target', rawurlencode( $target ), $initiator_url );
@@ -613,7 +614,7 @@ function shibboleth_authenticate_user() {
 		return $authenticate;
 	}
 
-	// look up existing account by username, with email as a fallback
+	// look up existing account by username, with email as a fallback.
 	$user_by = 'username';
 	$user = get_user_by( 'login', $username );
 	if ( ! $user ) {
@@ -621,7 +622,7 @@ function shibboleth_authenticate_user() {
 		$user = get_user_by( 'email', $email );
 	}
 
-	// if this account is not a Shibboleth account, then do account combine (if allowed)
+	// if this account is not a Shibboleth account, then do account combine (if allowed).
 	if ( is_object( $user ) && $user->ID && ! get_user_meta( $user->ID, 'shibboleth_account' ) ) {
 		$do_account_combine = false;
 		if ( 'username' === $user_by && ( 'allow' === $auto_combine_accounts || 'allow' === $manually_combine_accounts ) ) {
@@ -648,7 +649,7 @@ function shibboleth_authenticate_user() {
 		}
 	}
 
-	// create account if new user
+	// create account if new user.
 	if ( ! $user ) {
 		$user = shibboleth_create_new_user( $username, $email );
 		if ( is_wp_error( $user ) ) {
@@ -664,7 +665,7 @@ function shibboleth_authenticate_user() {
 		return new WP_Error( 'missing_data', $error_message );
 	}
 
-	// update user data
+	// update user data.
 	shibboleth_update_user_data( $user->ID );
 
 	$update = shibboleth_getoption( 'shibboleth_update_roles' );
@@ -703,7 +704,7 @@ function shibboleth_create_new_user( $user_login, $user_email ) {
 			return null;
 		}
 
-		// create account and flag as a shibboleth account
+		// create account and flag as a shibboleth account.
 		$user_id = wp_insert_user(
 			array(
 				'user_login' => $user_login,
@@ -720,7 +721,7 @@ function shibboleth_create_new_user( $user_login, $user_email ) {
 			$user = new WP_User( $user_id );
 			update_user_meta( $user->ID, 'shibboleth_account', true );
 
-			// always update user data and role on account creation
+			// always update user data and role on account creation.
 			shibboleth_update_user_data( $user->ID, true );
 			$user->set_role( $user_role );
 			do_action( 'shibboleth_set_user_roles', $user );
@@ -815,7 +816,7 @@ function shibboleth_get_managed_user_fields() {
  * the 'force_update' parameter is true, only the user fields marked as 'managed' fields will be
  * updated.
  *
- * @param int $user_id ID of the user to update.
+ * @param int     $user_id ID of the user to update.
  * @param boolean $force_update force update of user data, regardless of 'managed' flag on fields.
  * @uses apply_filters() Calls 'shibboleth_user_*' before setting user attributes,
  *       where '*' is one of: login, nicename, first_name, last_name,
@@ -893,11 +894,13 @@ function shibboleth_disable_login() {
 
 	if ( $disable && ! $bypass ) {
 		if ( isset( $_GET['action'] ) && 'lostpassword' === $_GET['action'] ) {
-			// Disable the ability to reset passwords from wp-login.php
+			// Disable the ability to reset passwords from wp-login.php.
 			add_filter( 'allow_password_reset', '__return_false' );
-		} elseif ( isset( $_POST['log'] ) || isset( $_POST['user_login'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			// Disable the ability to login using local authentication
+		} elseif ( isset( $_POST['log'] ) || isset( $_POST['user_login'] ) ) {
+			// Disable the ability to login using local authentication.
 			wp_die( esc_html( __( 'Shibboleth authentication is required.', 'shibboleth' ) ) );
+
+			check_admin_referer( 'log-in' );
 		}
 	}
 }


### PR DESCRIPTION
The WordPress-Core standard did not include all the relevant coding style checks, so this now uses and passes with the WordPress standard.

Although sanitize_url() has been redeemed by WordPress as the path forward, WPCS doesn't reflect this change yet, so we'll use esc_url_raw(), which is a viable alias, for now.