### PR TITLE
Added ability to extend WP session with a remember me checkbox when doing a shib login

### DIFF
--- a/assets/css/shibboleth_login_form.css
+++ b/assets/css/shibboleth_login_form.css
@@ -108,3 +108,46 @@
 .shibboleth-repositioned #shibboleth-wrap .button .dashicons {
 	font-size: 24px;
 }
+
+
+.shibboleth-remember-me-wrap {
+	margin-top: 1em;
+}
+.shibboleth-remember-me-wrap input[type="checkbox"] {
+	margin-right: .5em;
+}
+
+#shibboleth-wrap._rememberme-loading {
+	pointer-events: none;
+	position: relative;
+}
+
+#shibboleth-wrap._rememberme-loading * {
+	opacity: .4;
+}
+
+@keyframes L7 {
+	33%{background-size:calc(100%/3) 0%  ,calc(100%/3) 100%,calc(100%/3) 100%}
+	50%{background-size:calc(100%/3) 100%,calc(100%/3) 0%  ,calc(100%/3) 100%}
+	66%{background-size:calc(100%/3) 100%,calc(100%/3) 100%,calc(100%/3) 0%  }
+}
+#shibboleth-wrap._rememberme-loading::after {
+	content: '';
+	opacity: 1;
+	width: 60px;
+	aspect-ratio: 4;
+	--_g: no-repeat radial-gradient(circle closest-side,hsl(350, 20%, 28%) 90%,#0000);
+	background: 
+	var(--_g) 0%   50%,
+	var(--_g) 50%  50%,
+	var(--_g) 100% 50%;
+	background-size: calc(100%/3) 100%;
+	animation: L7 1s infinite linear;
+	position: absolute;
+	top: 50%;
+	left: 40%;
+}
+
+#shibboleth-wrap:has( .shibboleth-remember-me-wrap ) a.shibboleth-button[href*="wp-login.php"] {
+	float: none;
+}

--- a/assets/js/shibboleth_login_form.js
+++ b/assets/js/shibboleth_login_form.js
@@ -28,5 +28,27 @@ jQuery( document ).ready(
 		// positioning of the SSO UI.
 		loginForm.append( ssoWrap );
 		body.addClass( 'shibboleth-repositioned' );
+
+
+		var $checkbox = $( '#shibboleth-wrap input[name="shibboleth-lengthen-cookie"]' );
+		if( $checkbox ) {
+
+			$checkbox.on( 'change', function(e) {
+
+				var rememberMe = this.checked;
+				ssoWrap.addClass('_rememberme-loading');
+
+				var params = new URLSearchParams({
+					action: 'shibboleth_remember_me',
+					value: (rememberMe) ? '1' : '0',
+				});
+				var fetchurl = window.ajaxurl + '?' + params.toString();
+
+				fetch( fetchurl ).then( json => {
+					ssoWrap.removeClass('_rememberme-loading');
+				});
+				
+			});
+		}
 	}
 );

--- a/options-admin.php
+++ b/options-admin.php
@@ -130,6 +130,9 @@ function shibboleth_options_general() {
 		if ( ! defined( 'SHIBBOLETH_AUTO_LOGIN' ) ) {
 			update_site_option( 'shibboleth_auto_login', ! empty( $_POST['auto_login'] ) );
 		}
+		if ( ! defined( 'SHIBBOLETH_ALLOW_REMEMBERME' ) ) {
+			update_site_option( 'shibboleth_allow_rememberme', ! empty( $_POST['allow_rememberme'] ) );
+		}
 		if ( ! defined( 'SHIBBOLETH_BUTTON_TEXT' ) && isset( $_POST['button_text'] ) ) {
 			update_site_option( 'shibboleth_button_text', sanitize_text_field( wp_unslash( $_POST['button_text'] ) ) );
 		}
@@ -160,6 +163,8 @@ function shibboleth_options_general() {
 	list( $default_login, $from_constant ) = shibboleth_getoption( 'shibboleth_default_to_shib_login', false, false, true );
 	$constant = $constant || $from_constant;
 	list( $auto_login, $from_constant ) = shibboleth_getoption( 'shibboleth_auto_login', false, false, true );
+	$constant = $constant || $from_constant;
+	list( $allow_rememberme, $from_constant ) = shibboleth_getoption( 'shibboleth_allow_rememberme', false, false, true );
 	$constant = $constant || $from_constant;
 	list( $disable_local_auth, $from_constant ) = shibboleth_getoption( 'shibboleth_disable_local_auth', false, false, true );
 	$constant = $constant || $from_constant;
@@ -330,6 +335,24 @@ function shibboleth_options_general() {
 					__(
 						'If set, this option checks to see if a Shibboleth session exists on every page load, and,
 						if it does, forces a <code>wp_signon()</code> call and <code>wp_safe_redirect()</code> back to the <code>$_SERVER[\'REQUEST_URI\']</code>.',
+						'shibboleth'
+					)
+				);
+				?>
+				</p>
+			</td>
+		</tr>
+		<tr>
+			<th scope="row"><?php esc_html_e( 'Cookie Extension', 'shibboleth' ); ?></th>
+			<td>
+				<input type="checkbox" id="allow_rememberme" name="allow_rememberme" <?php checked( (bool) $allow_rememberme ); ?> <?php defined( 'SHIBBOLETH_ALLOW_REMEMBERME' ) && disabled( $allow_rememberme, SHIBBOLETH_ALLOW_REMEMBERME ); ?> />
+				<label for="allow_rememberme"><?php esc_html_e( 'Allow individual users to extend their shib cookie with a "Remember me" checkbox', 'shibboleth' ); ?></label>
+
+				<p>
+				<?php
+				echo wp_kses_post(
+					__(
+						'If set, this option displays a checkbox for "Remember Me" below the Shibboleth login button on the login page',
 						'shibboleth'
 					)
 				);

--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,10 @@ Yes, the plugin allows for all settings to be controlled via constants in `wp-co
    - Format: boolean
    - Available options: `true` to automatically login users with an existing Shibboleth session or `false` to not check for an existing Shibboleth session.
    - Example: `define('SHIBBOLETH_AUTO_LOGIN', true);`
+ - `SHIBBOLETH_ALLOW_REMEMBERME`
+   - Format: boolean
+   - Available options: `true` to include a "remember me" checkbox along with Shib login button to allow users to extend their cookie
+   - Example: `define( 'SHIBBOLETH_ALLOW_REMEMBERME', true );`
  - `SHIBBOLETH_BUTTON_TEXT`
    - Format: string
    - Available options: none


### PR DESCRIPTION
Currently when you use the Shib login flow, there's no way to extend your WordPress cookie. This PR adds that ability.