### PR TITLE
release: v2.5.1

### DIFF
--- a/.github/workflows/wp-plugin-ci-full.yml
+++ b/.github/workflows/wp-plugin-ci-full.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   phpcs:
-    name: PHP CodeSniffer
+    name: Full code check
 
     runs-on: ubuntu-latest
 
@@ -28,3 +28,10 @@ jobs:
     - name: Run PHPCS on all files
       run: |
         vendor/bin/phpcs -q -n --ignore=vendor --standard=WordPress --report=checkstyle $GITHUB_WORKSPACE | cs2pr
+
+    - name: Be evil and hide .eslintrc from plugin check
+      run: |
+        rm $GITHUB_WORKSPACE/.eslintrc
+
+    - name: Run plugin check
+      uses: wordpress/plugin-check-action@v1

--- a/options-admin.php
+++ b/options-admin.php
@@ -14,9 +14,9 @@
  */
 function shibboleth_admin_tabs( $current = 'general' ) {
 	$tabs = array(
-		'general' => __( 'General' ),
+		'general' => __( 'General', 'shibboleth' ),
 		'idps' => __( 'Identity Providers', 'shibboleth' ),
-		'user' => __( 'User' ),
+		'user' => __( 'User', 'shibboleth' ),
 		'authorization' => __( 'Authorization', 'shibboleth' ),
 		'logging' => __( 'Logging', 'shibboleth' ),
 	);
@@ -60,12 +60,12 @@ add_action( 'network_admin_menu', 'shibboleth_network_admin_panels' );
  */
 function shibboleth_header_fields() {
 	return array(
-		'username' => __( 'Username' ),
-		'first_name' => __( 'First Name' ),
-		'last_name' => __( 'Last Name' ),
-		'nickname' => __( 'Nickname' ),
+		'username' => __( 'Username', 'shibboleth' ),
+		'first_name' => __( 'First Name', 'shibboleth' ),
+		'last_name' => __( 'Last Name', 'shibboleth' ),
+		'nickname' => __( 'Nickname', 'shibboleth' ),
 		'display_name' => __( 'Display name', 'shibboleth' ),
-		'email' => __( 'Email' ),
+		'email' => __( 'Email', 'shibboleth' ),
 	);
 }
 
@@ -816,7 +816,7 @@ function shibboleth_options_authorization() {
 		<col></col>
 		<thead>
 			<tr>
-				<th scope="col"><?php esc_html_e( 'Role' ); ?></th>
+				<th scope="col"><?php esc_html_e( 'Role', 'shibboleth' ); ?></th>
 				<th scope="col"><?php esc_html_e( 'Header Name', 'shibboleth' ); ?></th>
 				<th scope="col"><?php esc_html_e( 'Header Value', 'shibboleth' ); ?></th>
 			</tr>
@@ -1017,7 +1017,7 @@ function shibboleth_options_page() {
 	wp_nonce_field( 'shibboleth_update_options' );
 	?>
 			<p class="submit">
-				<input type="submit" name="submit" class="button-primary" value="<?php esc_html_e( 'Save Changes' ); ?>" />
+				<input type="submit" name="submit" class="button-primary" value="<?php esc_html_e( 'Save Changes', 'shibboleth' ); ?>" />
 			</p>
 		</form>
 	</div>

--- a/options-user.php
+++ b/options-user.php
@@ -313,20 +313,20 @@ add_action( 'current_screen', 'shibboleth_disable_password_changes' );
  * @since 1.9
  */
 function shibboleth_link_accounts_notice() {
-	if ( isset( $_GET['shibboleth'] ) ) {
-		if ( 'failed' === $_GET['shibboleth'] ) {
-			$class = 'notice notice-error';
-			$message = __( 'Your account was unable to be linked with Shibboleth.', 'shibboleth' );
-		} elseif ( 'linked' === $_GET['shibboleth'] ) {
-			$class = 'notice notice-success is-dismissible';
-			$message = __( 'Your account has been linked with Shibboleth.', 'shibboleth' );
-		} elseif ( 'duplicate' === $_GET['shibboleth'] ) {
-			$class = 'notice notice-info is-dismissible';
-			$message = __( 'Your account is already linked with Shibboleth.', 'shibboleth' );
-		} else {
-			$class = '';
-			$message = '';
-		}
+	$message_code = isset( $_GET['shibboleth'] ) ? sanitize_key( wp_unslash( $_GET['shibboleth'] ) ) : '';
+
+	if ( 'failed' === $message_code ) {
+		$class = 'notice notice-error';
+		$message = __( 'Your account was unable to be linked with Shibboleth.', 'shibboleth' );
+	} elseif ( 'linked' === $message_code ) {
+		$class = 'notice notice-success is-dismissible';
+		$message = __( 'Your account has been linked with Shibboleth.', 'shibboleth' );
+	} elseif ( 'duplicate' === $message_code ) {
+		$class = 'notice notice-info is-dismissible';
+		$message = __( 'Your account is already linked with Shibboleth.', 'shibboleth' );
+	}
+
+	if ( isset( $message ) ) {
 		printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $message ) );
 	}
 }

--- a/options-user.php
+++ b/options-user.php
@@ -55,7 +55,7 @@ function shibboleth_disable_managed_fields() {
 		echo "
 		<script type=\"text/javascript\">
 			jQuery(function () {
-				jQuery('" . esc_attr( $selectors ) . "').attr('disabled', true);
+				jQuery('" . esc_attr( $selectors ) . "').attr('readonly', true);
 				jQuery('#first_name')
 					.parents('.form-table')
 					.before(
@@ -64,9 +64,9 @@ function shibboleth_disable_managed_fields() {
 						. "</p></div>'
 					);
 				jQuery('form#your-profile').submit(function () {
-					jQuery('" . esc_attr( $selectors ) . "').attr('disabled', false);
+					jQuery('" . esc_attr( $selectors ) . "').attr('readonly', false);
 				});
-				if (jQuery('#email').is(':disabled')) {
+				if (jQuery('#email').is(':readonly')) {
 					jQuery('#email-description').hide();
 				}
 			});

--- a/readme.txt
+++ b/readme.txt
@@ -133,9 +133,8 @@ Yes, the plugin allows for all settings to be controlled via constants in `wp-co
    - Available options: `true` to prevent users logging in using WordPress local authentication or `false` allow WordPress local authentication AND Shibboleth authentication.
    - Example: `define('SHIBBOLETH_DISABLE_LOCAL_AUTH', true);`
  - `SHIBBOLETH_HEADERS`
-   - Format: array (>= PHP 5.6) OR serialized string (< PHP 5.6)
+   - Format: array (>= PHP 5.6)
    - Available options: none
-   - PHP 5.5 (and earlier) example: `define( 'SHIBBOLETH_HEADERS', serialize( array( 'username' => array( 'name' => 'eppn' ), 'first_name' => array( 'name' => 'givenName', 'managed' => 'on' ), 'last_name' => array( 'name' => 'sn', 'managed' => 'on' ), 'nickname' => array( 'name' => 'eppn', 'managed' => 'off' ), 'display_name' => array( 'name' => 'displayName', 'managed' => 'off' ), 'email' => array( 'name' => 'mail', 'managed' => 'on' ) ) ) );`
    - PHP 5.6 (and above) example: `const SHIBBOLETH_HEADERS = array( 'username' => array( 'name' => 'eppn' ), 'first_name' => array( 'name' => 'givenName', 'managed' => 'on' ), 'last_name' => array( 'name' => 'sn', 'managed' => 'on' ), 'nickname' => array( 'name' => 'eppn', 'managed' => 'off' ), 'display_name' => array( 'name' => 'displayName', 'managed' => 'off' ), 'email' => array( 'name' => 'mail', 'managed' => 'on' ) );`
    - PHP 7.0 (and above) example: `define('SHIBBOLETH_HEADERS', array( 'username' => array( 'name' => 'eppn' ), 'first_name' => array( 'name' => 'givenName', 'managed' => 'on' ), 'last_name' => array( 'name' => 'sn', 'managed' => 'on' ), 'nickname' => array( 'name' => 'eppn', 'managed' => 'off' ), 'display_name' => array( 'name' => 'displayName', 'managed' => 'off' ), 'email' => array( 'name' => 'mail', 'managed' => 'on' ) ) );`
  - `SHIBBOLETH_CREATE_ACCOUNTS`
@@ -151,9 +150,8 @@ Yes, the plugin allows for all settings to be controlled via constants in `wp-co
    - Available options: `'disallow'` for the default "Prevent Manual Account Merging" option, `'allow'` for the "Allow Manual Account Merging" option, and `'bypass'` for the "Allow Manual Account Merging (Bypass Username Management)" option.
    - Example: `define('SHIBBOLETH_MANUALLY_COMBINE_ACCOUNTS', 'disallow');`
  - `SHIBBOLETH_ROLES`
-   - Format: array (>= PHP 5.6) OR serialized string (< PHP 5.6)
+   - Format: array (>= PHP 5.6)
    - Available options: none
-   - PHP 5.5 (and earlier) example: `define( 'SHIBBOLETH_ROLES', serialize( array( 'administrator' => array( 'header' => 'entitlement', 'value' => 'urn:mace:example.edu:entitlement:wordpress:admin' ), 'author' => array( 'header' => 'affiliation', 'value' => 'faculty' ) ) ) );`
    - PHP 5.6 (and above) example: `const SHIBBOLETH_ROLES = array( 'administrator' => array( 'header' => 'entitlement', 'value' => 'urn:mace:example.edu:entitlement:wordpress:admin' ), 'author' => array( 'header' => 'affiliation', 'value' => 'faculty' ) );`
    - PHP 7.0 (and above) example: `define('SHIBBOLETH_ROLES', array( 'administrator' => array( 'header' => 'entitlement', 'value' => 'urn:mace:example.edu:entitlement:wordpress:admin' ), 'author' => array( 'header' => 'affiliation', 'value' => 'faculty' ) ) );`
  - `SHIBBOLETH_DEFAULT_ROLE`
@@ -165,9 +163,8 @@ Yes, the plugin allows for all settings to be controlled via constants in `wp-co
    - Available options: `true` to automatically use Shibboleth data to update user role mappings each time the user logs in or `false` to only update role mappings when a user is initally created.
    - Example: `define('SHIBBOLETH_UPDATE_ROLES', true);`
  - `SHIBBOLETH_LOGGING`
-   - Format: array (>= PHP 5.6) OR serialized string (< PHP 5.6)
+   - Format: array (>= PHP 5.6)
    - Available options: account_merge, account_create, auth, role_update
-   - PHP 5.5 (and earlier) example: `define( 'SHIBBOLETH_LOGGING', serialize( array( 'account_merge', 'account_create', 'auth', 'role_update' ) ) );`
    - PHP 5.6 (and above) example: `const SHIBBOLETH_LOGGING = array( 'account_merge', 'account_create', 'auth', 'role_update' );`
    - PHP 7.0 (and above) example: `define('SHIBBOLETH_LOGGING', array( 'account_merge', 'account_create', 'auth', 'role_update' ) );`
  - `SHIBBOLETH_DISALLOW_FILE_MODS`

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,10 @@
 Contributors: michaelryanmcneill, willnorris, mitchoyoshitaka, jrchamp, dericcrago, bshelton229, Alhrath, dandalpiaz, masteradhoc, junaidkbr
 Tags: shibboleth, authentication, login, saml
 Requires at least: 4.0
-Tested up to: 6.4
+Tested up to: 6.7
 Requires PHP: 5.6
 Stable tag: 2.5.0
+License: Apache-2.0
 
 Allows WordPress to externalize user authentication and account creation to a Shibboleth Service Provider.
 

--- a/readme.txt
+++ b/readme.txt
@@ -188,13 +188,13 @@ This update increases the minimum PHP version to 5.6 and the minimum WordPress v
 This update re-implements a previously reverted <IfModule> conditional for three aliases of the Shibboleth Apache module: `mod_shib`, `mod_shib.c`, and `mod_shib.cpp`. If you run into issues related to this change, please open an issue on [GitHub](https://github.com/michaelryanmcneill/shibboleth/issues).
 
 = 2.0.2 =
-This update brings with it a major change to the way Shibboleth attributes are accessed from versions less than 2.0. For most users, no additional configuration will be necessary. If you are using a specialized server configuration, such as a Shibboleth Service Provider on a reverse proxy or a server configuration that results in environment variables being sent with the prefix REDIRECT_, you should see the changelog for additional details: https://wordpress.org/plugins/shibboleth/#developers
+Accessing Shibboleth attributes has changed. Typically, no additional configuration is necessary. Check the changelog if you have specialized server configurations, such as a Shibboleth Service Provider on a reverse proxy or a server configuration that prefixes environment variables with REDIRECT_.
 
 = 2.0.1 =
-This update brings with it a major change to the way Shibboleth attributes are accessed from versions less than 2.0. For most users, no additional configuration will be necessary. If you are using a specialized server configuration, such as a Shibboleth Service Provider on a reverse proxy or a server configuration that results in environment variables being sent with the prefix REDIRECT_, you should see the changelog for additional details: https://wordpress.org/plugins/shibboleth/#developers
+Accessing Shibboleth attributes has changed. Typically, no additional configuration is necessary. Check the changelog if you have specialized server configurations, such as a Shibboleth Service Provider on a reverse proxy or a server configuration that prefixes environment variables with REDIRECT_.
 
 = 2.0 =
-This update brings with it a major change to the way Shibboleth attributes are accessed. For most users, no additional configuration will be necessary. If you are using a specialized server configuration, such as a Shibboleth Service Provider on a reverse proxy or a server configuration that results in environment variables being sent with the prefix REDIRECT_, you should see the changelog for additional details: https://wordpress.org/plugins/shibboleth/#developers
+Accessing Shibboleth attributes has changed. Typically, no additional configuration is necessary. Check the changelog if you have specialized server configurations, such as a Shibboleth Service Provider on a reverse proxy or a server configuration that prefixes environment variables with REDIRECT_.
 
 == Changelog ==
 = version 2.5.0 (2024-10-11) =

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -890,7 +890,7 @@ function shibboleth_create_new_user( $user_login, $user_email ) {
 		}
 	} else {
 		shibboleth_log_message( 'auth', 'ERROR: User account does not exist and account creation is disabled.' );
-		return new WP_Error( 'no_access', __( 'You do not have sufficient access.' ) );
+		return new WP_Error( 'no_access', __( 'You do not have sufficient access.', 'shibboleth' ) );
 	}
 }
 

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -83,6 +83,10 @@ function shibboleth_getoption( $option, $default = false, $array = false, $compa
  * @return string|bool
  */
 function shibboleth_getenv( $var ) {
+	if ( empty( $var ) ) {
+		return false;
+	}
+
 	// Get the specified shibboleth attribute access method; if one isn't specified
 	// simply use standard environment variables since they're the safest.
 	$method = shibboleth_getoption( 'shibboleth_attribute_access_method', 'standard' );
@@ -423,7 +427,10 @@ function shibboleth_session_active( $auto_login = false ) {
 	$active = false;
 	$method = shibboleth_getoption( 'shibboleth_attribute_access_method' );
 	$shib_headers = shibboleth_getoption( 'shibboleth_headers', array(), true );
-	$session = shibboleth_getenv( $shib_headers['username']['name'] );
+	$session = null;
+	if ( isset( $shib_headers['username']['name'] ) ) {
+		$session = shibboleth_getenv( $shib_headers['username']['name'] );
+	}
 
 	if ( $session && 'http' !== $method ) {
 		$active = true;

--- a/shibboleth.php
+++ b/shibboleth.php
@@ -12,7 +12,7 @@
  * Version: 2.5.0
  * Requires PHP: 5.6
  * Requires at least: 4.0
- * License: Apache 2 (https://www.apache.org/licenses/LICENSE-2.0.html)
+ * License: Apache-2.0
  * Text Domain: shibboleth
  */
 


### PR DESCRIPTION
- options-user: use readonly instead of disabled
   - Reported by @MadtownLems, this avoids the false warning about unsaved changes on the profile page but does not prevent profile updates from being saved.
 - ci-full: add WordPress plugin check, which discovered:
   - specify domain for all strings
   - readme: shorten changelog messages
   - readme: bump Tested version, specify license
   - readme: cleanup outdated documentation
   - options-user: sanitize message code
   - shibboleth: fix variable warnings